### PR TITLE
Update message code to use Native Java arrays for all BasicTypes in messages.

### DIFF
--- a/rcljava/CMakeLists.txt
+++ b/rcljava/CMakeLists.txt
@@ -117,6 +117,14 @@ foreach(_jni_source ${${PROJECT_NAME}_jni_sources})
     PUBLIC
     ${JNI_INCLUDE_DIRS}
   )
+  
+  if(ANDROID)
+    # On Android, link against the android logging library
+    find_library(log-lib log)
+    target_link_libraries(${_target_name} ${log-lib})
+  else()
+    message(FATAL_ERROR "Not compiling for Android!")
+  endif()
 
   ament_export_jni_libraries(${_target_name})
 

--- a/rcljava/src/main/cpp/org_ros2_rcljava_node_NodeImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_node_NodeImpl.cpp
@@ -31,6 +31,24 @@
 
 #include "org_ros2_rcljava_node_NodeImpl.h"
 
+#ifdef __ANDROID__
+
+#include <android/log.h>
+
+#define TAG "NodeImpl"
+
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR,    TAG, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN,     TAG, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,     TAG, __VA_ARGS__)
+#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG,    TAG, __VA_ARGS__)
+
+#else
+
+#error "Not compiling for Android!"
+// TODO: implement logging for non-Android platforms
+
+#endif
+
 using rcljava_common::exceptions::rcljava_throw_exception;
 using rcljava_common::exceptions::rcljava_throw_rclexception;
 

--- a/rcljava/src/main/cpp/org_ros2_rcljava_publisher_PublisherImpl.cpp
+++ b/rcljava/src/main/cpp/org_ros2_rcljava_publisher_PublisherImpl.cpp
@@ -18,6 +18,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <chrono>
+#include <iostream>
 
 #include "rcl/error_handling.h"
 #include "rcl/event.h"
@@ -27,6 +29,24 @@
 
 #include "rcljava_common/exceptions.hpp"
 #include "rcljava_common/signatures.hpp"
+
+#ifdef __ANDROID__
+
+#include <android/log.h>
+
+#define TAG "PublisherImpl"
+
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR,    TAG, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN,     TAG, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO,     TAG, __VA_ARGS__)
+#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG,    TAG, __VA_ARGS__)
+
+#else
+
+#error "Not compiling for Android!"
+// TODO: implement logging for non-Android platforms
+
+#endif
 
 #include "org_ros2_rcljava_publisher_PublisherImpl.h"
 
@@ -49,9 +69,25 @@ Java_org_ros2_rcljava_publisher_PublisherImpl_nativePublish(
   convert_from_java_signature convert_from_java =
     reinterpret_cast<convert_from_java_signature>(jfrom_java_converter);
 
+  auto start = std::chrono::high_resolution_clock::now();
   void * raw_ros_message = convert_from_java(jmsg, nullptr);
+  auto end = std::chrono::high_resolution_clock::now();
 
+  std::chrono::duration<double> diff = end - start;
+  // Warn on long (>10ms) convert_from_java time
+  if (diff.count() * 1000.0 > 10.0) {
+    LOGW("convert_from_java() time = %f ms", diff.count() * 1000.0);
+  }
+  
+  start = std::chrono::high_resolution_clock::now();
   rcl_ret_t ret = rcl_publish(publisher, raw_ros_message, nullptr);
+  end = std::chrono::high_resolution_clock::now();
+  diff = end - start;
+
+  // Warn on long (>50ms) publish time
+  if (diff.count() * 1000.0 > 50.0) {
+    LOGW("Long rcl_publish() time = %f ms", diff.count() * 1000.0);
+  }
 
   destroy_ros_message_signature destroy_ros_message =
     reinterpret_cast<destroy_ros_message_signature>(jmsg_destructor_handle);

--- a/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/node/NodeImpl.java
@@ -757,6 +757,15 @@ public class NodeImpl implements Node {
     }
   }
 
+  public static <T> boolean contains(T[] array, T val) {
+    for (T t : array) {
+      if (t.equals(val)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public final Collection<NodeNameInfo> getNodeNames() {
     ArrayList<NodeNameInfo> nodeNames = new ArrayList();
     nativeGetNodeNames(this.handle, nodeNames);

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterVariant.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/ParameterVariant.java
@@ -100,31 +100,31 @@ public class ParameterVariant {
     this.value.setType(ParameterType.PARAMETER_STRING.getValue());
   }
 
-  public ParameterVariant(final String name, final Byte[] byteArrayValue) {
+  public ParameterVariant(final String name, final byte[] byteArrayValue) {
     this.name = name;
     this.value = new rcl_interfaces.msg.ParameterValue();
-    this.value.setByteArrayValue(Arrays.asList(byteArrayValue));
+    this.value.setByteArrayValue(byteArrayValue);
     this.value.setType(ParameterType.PARAMETER_BYTE_ARRAY.getValue());
   }
 
-  public ParameterVariant(final String name, final Boolean[] boolArrayValue) {
+  public ParameterVariant(final String name, final boolean[] boolArrayValue) {
     this.name = name;
     this.value = new rcl_interfaces.msg.ParameterValue();
-    this.value.setBoolArrayValue(Arrays.asList(boolArrayValue));
+    this.value.setBoolArrayValue(boolArrayValue);
     this.value.setType(ParameterType.PARAMETER_BOOL_ARRAY.getValue());
   }
 
-  public ParameterVariant(final String name, final Long[] integerArrayValue) {
+  public ParameterVariant(final String name, final long[] integerArrayValue) {
     this.name = name;
     this.value = new rcl_interfaces.msg.ParameterValue();
-    this.value.setIntegerArrayValue(Arrays.asList(integerArrayValue));
+    this.value.setIntegerArrayValue(integerArrayValue);
     this.value.setType(ParameterType.PARAMETER_INTEGER_ARRAY.getValue());
   }
 
-  public ParameterVariant(final String name, final Double[] doubleArrayValue) {
+  public ParameterVariant(final String name, final double[] doubleArrayValue) {
     this.name = name;
     this.value = new rcl_interfaces.msg.ParameterValue();
-    this.value.setDoubleArrayValue(Arrays.asList(doubleArrayValue));
+    this.value.setDoubleArrayValue(doubleArrayValue);
     this.value.setType(ParameterType.PARAMETER_DOUBLE_ARRAY.getValue());
   }
 
@@ -203,32 +203,32 @@ public class ParameterVariant {
     return this.value.getBoolValue();
   }
 
-  public final Byte[] asByteArray() {
+  public final byte[] asByteArray() {
     if (getType() != ParameterType.PARAMETER_BYTE_ARRAY) {
       throw new IllegalArgumentException("Invalid type");
     }
-    return this.value.getByteArrayValue().toArray(new Byte[0]);
+    return this.value.getByteArrayValue();
   }
 
-  public final Boolean[] asBooleanArray() {
+  public final boolean[] asBooleanArray() {
     if (getType() != ParameterType.PARAMETER_BOOL_ARRAY) {
       throw new IllegalArgumentException("Invalid type");
     }
-    return this.value.getBoolArrayValue().toArray(new Boolean[0]);
+    return this.value.getBoolArrayValue();
   }
 
-  public final Long[] asIntegerArray() {
+  public final long[] asIntegerArray() {
     if (getType() != ParameterType.PARAMETER_INTEGER_ARRAY) {
       throw new IllegalArgumentException("Invalid type");
     }
-    return this.value.getIntegerArrayValue().toArray(new Long[0]);
+    return this.value.getIntegerArrayValue();
   }
 
-  public final Double[] asDoubleArray() {
+  public final double[] asDoubleArray() {
     if (getType() != ParameterType.PARAMETER_DOUBLE_ARRAY) {
       throw new IllegalArgumentException("Invalid type");
     }
-    return this.value.getDoubleArrayValue().toArray(new Double[0]);
+    return this.value.getDoubleArrayValue();
   }
 
   public final String[] asStringArray() {
@@ -256,13 +256,13 @@ public class ParameterVariant {
       case rcl_interfaces.msg.ParameterType.PARAMETER_STRING:
         return new ParameterVariant(parameter.getName(), parameter.getValue().getStringValue());
       case rcl_interfaces.msg.ParameterType.PARAMETER_BYTE_ARRAY:
-        return new ParameterVariant(parameter.getName(), parameter.getValue().getByteArrayValue().toArray(new Byte[0]));
+        return new ParameterVariant(parameter.getName(), parameter.getValue().getByteArrayValue());
       case rcl_interfaces.msg.ParameterType.PARAMETER_BOOL_ARRAY:
-        return new ParameterVariant(parameter.getName(), parameter.getValue().getBoolArrayValue().toArray(new Boolean[0]));
+        return new ParameterVariant(parameter.getName(), parameter.getValue().getBoolArrayValue());
       case rcl_interfaces.msg.ParameterType.PARAMETER_INTEGER_ARRAY:
-        return new ParameterVariant(parameter.getName(), parameter.getValue().getIntegerArrayValue().toArray(new Long[0]));
+        return new ParameterVariant(parameter.getName(), parameter.getValue().getIntegerArrayValue());
       case rcl_interfaces.msg.ParameterType.PARAMETER_DOUBLE_ARRAY:
-        return new ParameterVariant(parameter.getName(), parameter.getValue().getDoubleArrayValue().toArray(new Double[0]));
+        return new ParameterVariant(parameter.getName(), parameter.getValue().getDoubleArrayValue());
       case rcl_interfaces.msg.ParameterType.PARAMETER_STRING_ARRAY:
         return new ParameterVariant(parameter.getName(), parameter.getValue().getStringArrayValue().toArray(new String[0]));
       case rcl_interfaces.msg.ParameterType.PARAMETER_NOT_SET:

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClient.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClient.java
@@ -13,50 +13,50 @@
  * limitations under the License.
  */
 
-package org.ros2.rcljava.parameters.client;
+ package org.ros2.rcljava.parameters.client;
 
-import java.util.List;
-import java.util.concurrent.Future;
-
-import org.ros2.rcljava.consumers.Consumer;
-import org.ros2.rcljava.parameters.ParameterType;
-import org.ros2.rcljava.parameters.ParameterVariant;
-
-public interface AsyncParametersClient {
-  public Future<List<ParameterVariant>> getParameters(final List<String> names);
-
-  public Future<List<ParameterVariant>> getParameters(
-      final List<String> names, final Consumer<Future<List<ParameterVariant>>> callback);
-
-  public Future<List<ParameterType>> getParameterTypes(final List<String> names);
-
-  public Future<List<ParameterType>> getParameterTypes(
-      final List<String> names, final Consumer<Future<List<ParameterType>>> callback);
-
-  public Future<List<rcl_interfaces.msg.SetParametersResult>> setParameters(
-      final List<ParameterVariant> parameters);
-
-  public Future<List<rcl_interfaces.msg.SetParametersResult>> setParameters(
-      final List<ParameterVariant> parameters,
-      final Consumer<Future<List<rcl_interfaces.msg.SetParametersResult>>> callback);
-
-  public Future<rcl_interfaces.msg.SetParametersResult> setParametersAtomically(
-      final List<ParameterVariant> parameters);
-
-  public Future<rcl_interfaces.msg.SetParametersResult> setParametersAtomically(
-      final List<ParameterVariant> parameters,
-      final Consumer<Future<rcl_interfaces.msg.SetParametersResult>> callback);
-
-  public Future<rcl_interfaces.msg.ListParametersResult> listParameters(
-      final List<String> prefixes, long depth);
-
-  public Future<rcl_interfaces.msg.ListParametersResult> listParameters(final List<String> prefixes,
-      long depth, final Consumer<Future<rcl_interfaces.msg.ListParametersResult>> callback);
-
-  public Future<List<rcl_interfaces.msg.ParameterDescriptor>> describeParameters(
-      final List<String> names);
-
-  public Future<List<rcl_interfaces.msg.ParameterDescriptor>> describeParameters(
-      final List<String> names,
-      final Consumer<Future<List<rcl_interfaces.msg.ParameterDescriptor>>> callback);
-}
+ import java.util.List;
+ import java.util.concurrent.Future;
+ 
+ import org.ros2.rcljava.consumers.Consumer;
+ import org.ros2.rcljava.parameters.ParameterType;
+ import org.ros2.rcljava.parameters.ParameterVariant;
+ 
+ public interface AsyncParametersClient {
+   public Future<List<ParameterVariant>> getParameters(final List<String> names);
+ 
+   public Future<List<ParameterVariant>> getParameters(
+       final List<String> names, final Consumer<Future<List<ParameterVariant>>> callback);
+ 
+   public Future<List<ParameterType>> getParameterTypes(final List<String> names);
+ 
+   public Future<List<ParameterType>> getParameterTypes(
+       final List<String> names, final Consumer<Future<List<ParameterType>>> callback);
+ 
+   public Future<List<rcl_interfaces.msg.SetParametersResult>> setParameters(
+       final List<ParameterVariant> parameters);
+ 
+   public Future<List<rcl_interfaces.msg.SetParametersResult>> setParameters(
+       final List<ParameterVariant> parameters,
+       final Consumer<Future<List<rcl_interfaces.msg.SetParametersResult>>> callback);
+ 
+   public Future<rcl_interfaces.msg.SetParametersResult> setParametersAtomically(
+       final List<ParameterVariant> parameters);
+ 
+   public Future<rcl_interfaces.msg.SetParametersResult> setParametersAtomically(
+       final List<ParameterVariant> parameters,
+       final Consumer<Future<rcl_interfaces.msg.SetParametersResult>> callback);
+ 
+   public Future<rcl_interfaces.msg.ListParametersResult> listParameters(
+       final List<String> prefixes, long depth);
+ 
+   public Future<rcl_interfaces.msg.ListParametersResult> listParameters(final List<String> prefixes,
+       long depth, final Consumer<Future<rcl_interfaces.msg.ListParametersResult>> callback);
+ 
+   public Future<List<rcl_interfaces.msg.ParameterDescriptor>> describeParameters(
+       final List<String> names);
+ 
+   public Future<List<rcl_interfaces.msg.ParameterDescriptor>> describeParameters(
+       final List<String> names,
+       final Consumer<Future<List<rcl_interfaces.msg.ParameterDescriptor>>> callback);
+ }

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/AsyncParametersClientImpl.java
@@ -151,13 +151,13 @@ public class AsyncParametersClientImpl implements AsyncParametersClient {
         request, new Consumer<Future<rcl_interfaces.srv.GetParameterTypes_Response>>() {
           public void accept(final Future<rcl_interfaces.srv.GetParameterTypes_Response> future) {
             List<ParameterType> parameterTypes = new ArrayList<ParameterType>();
-            List<Byte> pts = null;
+            byte[] pts = null;
             try {
               pts = future.get().getTypes();
             } catch (Exception e) {
               // TODO(esteve): do something
             }
-            for (Byte pt : pts) {
+            for (byte pt : pts) {
               parameterTypes.add(ParameterType.fromByte(pt));
             }
             futureResult.set(parameterTypes);

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClient.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClient.java
@@ -13,34 +13,34 @@
  * limitations under the License.
  */
 
-package org.ros2.rcljava.parameters.client;
+ package org.ros2.rcljava.parameters.client;
 
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
-import org.ros2.rcljava.consumers.Consumer;
-import org.ros2.rcljava.parameters.ParameterType;
-import org.ros2.rcljava.parameters.ParameterVariant;
-
-public interface SyncParametersClient {
-  public List<ParameterVariant> getParameters(final List<String> names)
-      throws InterruptedException, ExecutionException;
-
-  public List<ParameterType> getParameterTypes(final List<String> names)
-      throws InterruptedException, ExecutionException;
-
-  public List<rcl_interfaces.msg.SetParametersResult> setParameters(
-      final List<ParameterVariant> parameters)
-      throws InterruptedException, ExecutionException;
-
-  public rcl_interfaces.msg.SetParametersResult setParametersAtomically(
-      final List<ParameterVariant> parameters)
-      throws InterruptedException, ExecutionException;
-
-  public rcl_interfaces.msg.ListParametersResult listParameters(final List<String> prefixes,
-      long depth) throws InterruptedException, ExecutionException;
-
-  public List<rcl_interfaces.msg.ParameterDescriptor> describeParameters(
-      final List<String> names) throws InterruptedException, ExecutionException;
-}
+ import java.util.List;
+ import java.util.concurrent.ExecutionException;
+ import java.util.concurrent.Future;
+ 
+ import org.ros2.rcljava.consumers.Consumer;
+ import org.ros2.rcljava.parameters.ParameterType;
+ import org.ros2.rcljava.parameters.ParameterVariant;
+ 
+ public interface SyncParametersClient {
+   public List<ParameterVariant> getParameters(final List<String> names)
+       throws InterruptedException, ExecutionException;
+ 
+   public List<ParameterType> getParameterTypes(final List<String> names)
+       throws InterruptedException, ExecutionException;
+ 
+   public List<rcl_interfaces.msg.SetParametersResult> setParameters(
+       final List<ParameterVariant> parameters)
+       throws InterruptedException, ExecutionException;
+ 
+   public rcl_interfaces.msg.SetParametersResult setParametersAtomically(
+       final List<ParameterVariant> parameters)
+       throws InterruptedException, ExecutionException;
+ 
+   public rcl_interfaces.msg.ListParametersResult listParameters(final List<String> prefixes,
+       long depth) throws InterruptedException, ExecutionException;
+ 
+   public List<rcl_interfaces.msg.ParameterDescriptor> describeParameters(
+       final List<String> names) throws InterruptedException, ExecutionException;
+ }

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClientImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/client/SyncParametersClientImpl.java
@@ -13,162 +13,162 @@
  * limitations under the License.
  */
 
-package org.ros2.rcljava.parameters.client;
+ package org.ros2.rcljava.parameters.client;
 
-import java.lang.ref.WeakReference;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
-import org.ros2.rcljava.client.Client;
-import org.ros2.rcljava.concurrent.RCLFuture;
-import org.ros2.rcljava.consumers.Consumer;
-import org.ros2.rcljava.executors.Executor;
-import org.ros2.rcljava.node.Node;
-import org.ros2.rcljava.qos.QoSProfile;
-import org.ros2.rcljava.parameters.ParameterType;
-import org.ros2.rcljava.parameters.ParameterVariant;
-
-public class SyncParametersClientImpl implements SyncParametersClient {
-  private static class ConsumerHelper<T> implements Consumer<Future<T>> {
-    private RCLFuture<T> resultFuture;
-
-    public void accept(final Future<T> future) {
-      T result = null;
-      try {
-        result = future.get();
-      } catch (Exception e) {
-        // TODO(esteve): do something
-      }
-      this.resultFuture.set(result);
-    }
-
-    public ConsumerHelper(RCLFuture<T> resultFuture) {
-      this.resultFuture = resultFuture;
-    }
-  }
-
-  private Executor executor;
-
-  public AsyncParametersClient asyncParametersClient;
-
-  public SyncParametersClientImpl(final Node node, final String remoteName,
-      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
-    this.asyncParametersClient = new AsyncParametersClientImpl(node, remoteName, qosProfile);
-  }
-
-  public SyncParametersClientImpl(final Node node, final QoSProfile qosProfile)
-      throws NoSuchFieldException, IllegalAccessException {
-    this(node, "", qosProfile);
-  }
-
-  public SyncParametersClientImpl(final Node node, final String remoteName)
-      throws NoSuchFieldException, IllegalAccessException {
-    this(node, remoteName, QoSProfile.PARAMETERS);
-  }
-
-  public SyncParametersClientImpl(final Node node)
-      throws NoSuchFieldException, IllegalAccessException {
-    this(node, "", QoSProfile.PARAMETERS);
-  }
-
-  public SyncParametersClientImpl(final Executor executor, final Node node, final String remoteName,
-      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
-    this.executor = executor;
-    this.asyncParametersClient = new AsyncParametersClientImpl(node, remoteName, qosProfile);
-  }
-
-  public SyncParametersClientImpl(final Executor executor, final Node node,
-      final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
-    this(executor, node, "", qosProfile);
-  }
-
-  public SyncParametersClientImpl(final Executor executor, final Node node, final String remoteName)
-      throws NoSuchFieldException, IllegalAccessException {
-    this(executor, node, remoteName, QoSProfile.PARAMETERS);
-  }
-
-  public SyncParametersClientImpl(final Executor executor, final Node node)
-      throws NoSuchFieldException, IllegalAccessException {
-    this(executor, node, "", QoSProfile.PARAMETERS);
-  }
-
-  public List<ParameterVariant> getParameters(final List<String> names)
-      throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<List<ParameterVariant>> future = new RCLFuture<List<ParameterVariant>>(executor);
-      asyncParametersClient.getParameters(
-          names, new ConsumerHelper<List<ParameterVariant>>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.getParameters(names, null).get();
-    }
-  }
-
-  public List<ParameterType> getParameterTypes(final List<String> names)
-      throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<List<ParameterType>> future = new RCLFuture<List<ParameterType>>(executor);
-      asyncParametersClient.getParameterTypes(
-          names, new ConsumerHelper<List<ParameterType>>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.getParameterTypes(names, null).get();
-    }
-  }
-
-  public List<rcl_interfaces.msg.SetParametersResult> setParameters(
-      final List<ParameterVariant> parameters) throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<List<rcl_interfaces.msg.SetParametersResult>> future =
-          new RCLFuture<List<rcl_interfaces.msg.SetParametersResult>>(executor);
-      asyncParametersClient.setParameters(
-          parameters, new ConsumerHelper<List<rcl_interfaces.msg.SetParametersResult>>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.setParameters(parameters, null).get();
-    }
-  }
-
-  public rcl_interfaces.msg.SetParametersResult setParametersAtomically(
-      final List<ParameterVariant> parameters) throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<rcl_interfaces.msg.SetParametersResult> future =
-          new RCLFuture<rcl_interfaces.msg.SetParametersResult>(executor);
-      asyncParametersClient.setParametersAtomically(
-          parameters, new ConsumerHelper<rcl_interfaces.msg.SetParametersResult>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.setParametersAtomically(parameters, null).get();
-    }
-  }
-
-  public rcl_interfaces.msg.ListParametersResult listParameters(
-      final List<String> prefixes, long depth) throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<rcl_interfaces.msg.ListParametersResult> future =
-          new RCLFuture<rcl_interfaces.msg.ListParametersResult>(executor);
-      asyncParametersClient.listParameters(
-          prefixes, depth, new ConsumerHelper<rcl_interfaces.msg.ListParametersResult>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.listParameters(prefixes, depth, null).get();
-    }
-  }
-
-  public List<rcl_interfaces.msg.ParameterDescriptor> describeParameters(final List<String> names)
-      throws InterruptedException, ExecutionException {
-    if (executor != null) {
-      RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>> future =
-          new RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>>(executor);
-      asyncParametersClient.describeParameters(
-          names, new ConsumerHelper<List<rcl_interfaces.msg.ParameterDescriptor>>(future));
-      return future.get();
-    } else {
-      return asyncParametersClient.describeParameters(names, null).get();
-    }
-  }
-}
+ import java.lang.ref.WeakReference;
+ 
+ import java.util.ArrayList;
+ import java.util.List;
+ 
+ import java.util.concurrent.ExecutionException;
+ import java.util.concurrent.Future;
+ 
+ import org.ros2.rcljava.client.Client;
+ import org.ros2.rcljava.concurrent.RCLFuture;
+ import org.ros2.rcljava.consumers.Consumer;
+ import org.ros2.rcljava.executors.Executor;
+ import org.ros2.rcljava.node.Node;
+ import org.ros2.rcljava.qos.QoSProfile;
+ import org.ros2.rcljava.parameters.ParameterType;
+ import org.ros2.rcljava.parameters.ParameterVariant;
+ 
+ public class SyncParametersClientImpl implements SyncParametersClient {
+   private static class ConsumerHelper<T> implements Consumer<Future<T>> {
+     private RCLFuture<T> resultFuture;
+ 
+     public void accept(final Future<T> future) {
+       T result = null;
+       try {
+         result = future.get();
+       } catch (Exception e) {
+         // TODO(esteve): do something
+       }
+       this.resultFuture.set(result);
+     }
+ 
+     public ConsumerHelper(RCLFuture<T> resultFuture) {
+       this.resultFuture = resultFuture;
+     }
+   }
+ 
+   private Executor executor;
+ 
+   public AsyncParametersClient asyncParametersClient;
+ 
+   public SyncParametersClientImpl(final Node node, final String remoteName,
+       final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+     this.asyncParametersClient = new AsyncParametersClientImpl(node, remoteName, qosProfile);
+   }
+ 
+   public SyncParametersClientImpl(final Node node, final QoSProfile qosProfile)
+       throws NoSuchFieldException, IllegalAccessException {
+     this(node, "", qosProfile);
+   }
+ 
+   public SyncParametersClientImpl(final Node node, final String remoteName)
+       throws NoSuchFieldException, IllegalAccessException {
+     this(node, remoteName, QoSProfile.PARAMETERS);
+   }
+ 
+   public SyncParametersClientImpl(final Node node)
+       throws NoSuchFieldException, IllegalAccessException {
+     this(node, "", QoSProfile.PARAMETERS);
+   }
+ 
+   public SyncParametersClientImpl(final Executor executor, final Node node, final String remoteName,
+       final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+     this.executor = executor;
+     this.asyncParametersClient = new AsyncParametersClientImpl(node, remoteName, qosProfile);
+   }
+ 
+   public SyncParametersClientImpl(final Executor executor, final Node node,
+       final QoSProfile qosProfile) throws NoSuchFieldException, IllegalAccessException {
+     this(executor, node, "", qosProfile);
+   }
+ 
+   public SyncParametersClientImpl(final Executor executor, final Node node, final String remoteName)
+       throws NoSuchFieldException, IllegalAccessException {
+     this(executor, node, remoteName, QoSProfile.PARAMETERS);
+   }
+ 
+   public SyncParametersClientImpl(final Executor executor, final Node node)
+       throws NoSuchFieldException, IllegalAccessException {
+     this(executor, node, "", QoSProfile.PARAMETERS);
+   }
+ 
+   public List<ParameterVariant> getParameters(final List<String> names)
+       throws InterruptedException, ExecutionException {
+     if (executor != null) {
+       RCLFuture<List<ParameterVariant>> future = new RCLFuture<List<ParameterVariant>>(executor);
+       asyncParametersClient.getParameters(
+           names, new ConsumerHelper<List<ParameterVariant>>(future));
+       return future.get();
+     } else {
+       return asyncParametersClient.getParameters(names, null).get();
+     }
+   }
+ 
+   public List<ParameterType> getParameterTypes(final List<String> names)
+       throws InterruptedException, ExecutionException {
+     if (executor != null) {
+       RCLFuture<List<ParameterType>> future = new RCLFuture<List<ParameterType>>(executor);
+       asyncParametersClient.getParameterTypes(
+           names, new ConsumerHelper<List<ParameterType>>(future));
+       return future.get();
+     } else {
+       return asyncParametersClient.getParameterTypes(names, null).get();
+     }
+   }
+ 
+   public List<rcl_interfaces.msg.SetParametersResult> setParameters(
+       final List<ParameterVariant> parameters) throws InterruptedException, ExecutionException {
+     if (executor != null) {
+       RCLFuture<List<rcl_interfaces.msg.SetParametersResult>> future =
+           new RCLFuture<List<rcl_interfaces.msg.SetParametersResult>>(executor);
+       asyncParametersClient.setParameters(
+           parameters, new ConsumerHelper<List<rcl_interfaces.msg.SetParametersResult>>(future));
+       return future.get();
+     } else {
+       return asyncParametersClient.setParameters(parameters, null).get();
+     }
+   }
+ 
+   public rcl_interfaces.msg.SetParametersResult setParametersAtomically(
+       final List<ParameterVariant> parameters) throws InterruptedException, ExecutionException {
+     if (executor != null) {
+       RCLFuture<rcl_interfaces.msg.SetParametersResult> future =
+           new RCLFuture<rcl_interfaces.msg.SetParametersResult>(executor);
+       asyncParametersClient.setParametersAtomically(
+           parameters, new ConsumerHelper<rcl_interfaces.msg.SetParametersResult>(future));
+       return future.get();
+     } else {
+       return asyncParametersClient.setParametersAtomically(parameters, null).get();
+     }
+   }
+ 
+   public rcl_interfaces.msg.ListParametersResult listParameters(
+       final List<String> prefixes, long depth) throws InterruptedException, ExecutionException {
+     if (executor != null) {
+       RCLFuture<rcl_interfaces.msg.ListParametersResult> future =
+           new RCLFuture<rcl_interfaces.msg.ListParametersResult>(executor);
+       asyncParametersClient.listParameters(
+           prefixes, depth, new ConsumerHelper<rcl_interfaces.msg.ListParametersResult>(future));
+       return future.get();
+     } else {
+       return asyncParametersClient.listParameters(prefixes, depth, null).get();
+     }
+   }
+ 
+   public List<rcl_interfaces.msg.ParameterDescriptor> describeParameters(final List<String> names)
+       throws InterruptedException, ExecutionException {
+     if (executor != null) {
+       RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>> future =
+           new RCLFuture<List<rcl_interfaces.msg.ParameterDescriptor>>(executor);
+       asyncParametersClient.describeParameters(
+           names, new ConsumerHelper<List<rcl_interfaces.msg.ParameterDescriptor>>(future));
+       return future.get();
+     } else {
+       return asyncParametersClient.describeParameters(names, null).get();
+     }
+   }
+ }

--- a/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterServiceImpl.java
+++ b/rcljava/src/main/java/org/ros2/rcljava/parameters/service/ParameterServiceImpl.java
@@ -68,9 +68,11 @@ public class ParameterServiceImpl implements ParameterService {
               rcl_interfaces.srv.GetParameterTypes_Request request,
               rcl_interfaces.srv.GetParameterTypes_Response response) {
             List<ParameterType> types = node.getParameterTypes(request.getNames());
-            List<Byte> ptypes = new ArrayList<Byte>();
-            for (ParameterType type : types) {
-              ptypes.add(type.getValue());
+            byte[] ptypes = new byte[types.size()];
+            int i = 0;
+            for (org.ros2.rcljava.parameters.ParameterType type : types) {
+              ptypes[i] = type.getValue();
+              i++;
             }
             response.setTypes(ptypes);
           }

--- a/ros2_java_android.repos
+++ b/ros2_java_android.repos
@@ -177,17 +177,13 @@ repositories:
     version: iron
   ros2-java/ament_java:
     type: git
-    url: https://github.com/ros2-java/ament_java.git
-    version: main
+    url: https://github.com/skalldri/ament_java.git
+    version: iron
   ros2-java/ros2_java:
     type: git
     url: https://github.com/skalldri/ros2_java.git
-    version: main
+    version: iron-java-primitive-arrays
   ros2-java/ros2_android:
     type: git
     url: https://github.com/skalldri/ros2_android.git
-    version: main
-  ros2-java/ros2_android_examples:
-    type: git
-    url: https://github.com/ros2-java/ros2_android_examples.git
-    version: main
+    version: iron

--- a/rosidl_generator_java/resource/msg.cpp.em
+++ b/rosidl_generator_java/resource/msg.cpp.em
@@ -401,13 +401,19 @@ normalized_type = get_normalized_type(member.type)
 @[    if isinstance(member.type.value_type, BasicType)]@
   // BasicType
   auto _jfield_@(member.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(member.name)", "[@(get_jni_primitive_signature(member.type.value_type))");
-  @[    if isinstance(member.type, Array)]@
+@[    if isinstance(member.type, Array)]@
   auto _jfield_@(member.name)_array_size = @(member.type.size);
 @[      else]@
   auto _jfield_@(member.name)_array_size = _ros_message->@(member.name).size;
 @[      end if]@
   auto _jarray_@(member.name)_array = env->@(get_jni_array_func(member.type.value_type, 0))(_jfield_@(member.name)_array_size);
   jobject _jarray_list_@(member.name)_obj = reinterpret_cast<jobject>(_jarray_@(member.name)_array);
+@[      if isinstance(member.type, Array)]@
+  auto _ros_@(member.name)_element = _ros_message->@(member.name);
+@[      else]@
+  auto _ros_@(member.name)_element = _ros_message->@(member.name).data;
+@[      end if]@
+  env->@(get_jni_array_func(member.type.value_type, 4))(_jarray_@(member.name)_array, 0, _jfield_@(member.name)_array_size, reinterpret_cast<j@(get_java_type(member.type.value_type, use_primitives=True))*>(_ros_@(member.name)_element));
 @[    elif isinstance(member.type.value_type, AbstractGenericString)]@
   // AbstractGenericString
   auto _jfield_@(member.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(member.name)", "L@(list_jni_type);");
@@ -487,7 +493,7 @@ normalized_type = get_normalized_type(member.type)
 jni_signature = get_jni_signature(member.type)
 set_method_name = 'Set%sField' % get_java_type(member.type, use_primitives=True).capitalize()
 }@
-  auto _jfield_@(member.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(member.name)", "[@(jni_signature)");
+  auto _jfield_@(member.name)_fid = env->GetFieldID(_j@(msg_normalized_type)_class_global, "@(member.name)", "@(jni_signature)");
   env->@(set_method_name)(_jmessage_obj, _jfield_@(member.name)_fid, _ros_message->@(member.name));
 @[    else]@
   auto _jfield_@(member.name)_fid = env->GetFieldID(


### PR DESCRIPTION
I've been using the ROS2 Java bindings to get sensor data off a Segway Loomo.

An issue I've run into is that trying to emit sensor_msgs/Image messages is incredibly slow (~1.5Hz max rate for a 640x480 RGB image). 

Tests showed that robot has plenty of compute and network bandwidth available to transmit the images at much higher rate, but it's not being utilized. So I decided to start profiling the ROS2 Java code.

I discovered that the way the code copies images is very, very slow. Internally, sensor_msgs/Image are represented as large `sequences` of `bytes`. The ROS2 Java representation for any `sequence` is a `List<>`.

Because `List<>` Java objects have limited native binding support, the C++ `covert_from_java` / `convert_to_java` functions need to execute 2 JNI / JVM function calls to access each element:
- A "List Get At Index" function
- A "jobject get value" function

This means that transmitting a single RGB image takes millions of function calls in and out of the JVM.

A much faster implementation would instead leverage the JNI `Get<Type>ArrayRegion()` functions, which will directly copy the contents of a Java native array into a destination C++ buffer in a single function call through the JNI / JVM layer. However, to do this, we must use _native_ Java arrays. `Lists<>` and `ArrayLists<>` are not compatible with this method.

So that's what this PR does. It carves out a special-case in all the Java message generation and processing code so that any `sequence` of a pure `BasicType` gets represented in Java as a native array, and the message processing code has been updated to use `Get<Type>ArrayRegion()`.

In my testing on the Loomo, this results in a ~200x speedup.
